### PR TITLE
I created a helper function called getStatusEmoji that takes the appl…

### DIFF
--- a/web/src/pages/MyApplications.jsx
+++ b/web/src/pages/MyApplications.jsx
@@ -45,9 +45,53 @@ function MyApplications() {
           status: 'Pending',
         },
       ];
+  
+  // Helper function for emoji based on status
+  const getStatusEmoji = (status) => {
+    switch (status) {
+      case 'Accepted':
+        return '✅'; // Green Check Mark
+      case 'Rejected':
+        return '❌'; // Red Cross Mark
+      default:
+        return '⏳'; // Hourglass for Pending
+    }
+  };
+
   return (
-    <div>MyApplications</div>
-  )
+    <div className="p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {applications.map((application, index) => (
+        <div
+          key={index}
+          className={`border rounded-lg p-4 shadow-lg transform transition duration-300 hover:scale-105 ${
+            application.status === 'Accepted'
+              ? 'bg-green-50 border-green-200'
+              : application.status === 'Rejected'
+              ? 'bg-red-50 border-red-200'
+              : 'bg-yellow-50 border-yellow-200'
+          }`}
+        >
+          <div className="flex justify-between items-center mb-2">
+            <h3 className="text-xl font-semibold">{application.role}</h3>
+            <span className="text-lg">{getStatusEmoji(application.status)}</span>
+          </div>
+          <p className="text-sm text-gray-700">Department: {application.department}</p>
+          <p className="text-sm text-gray-600">Applied on: {application.dateOfApplication}</p>
+          <span
+            className={`inline-block px-3 py-1 mt-3 rounded-full text-xs font-bold ${
+              application.status === 'Accepted'
+                ? 'bg-green-200 text-green-800'
+                : application.status === 'Rejected'
+                ? 'bg-red-200 text-red-800'
+                : 'bg-yellow-200 text-yellow-800'
+            }`}
+          >
+            {application.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
-export default MyApplications
+export default MyApplications;


### PR DESCRIPTION

# 📌 Pull Request Type:

Let's define the purpose of this PR:

- [ ] 🚀 **Heads up:** No need for extended review. This will be merged shortly after being opened.
- [ ] 🛠 **WIP (Work in Progress):** This PR is not yet ready for feedback, shared as a "private" progress log.
- [ ] 💬 **Early Feedback:** WIP, but feedback on the approach or logic is requested.
- [X] 🔍 **Full Review:** Ready for a comprehensive review to ensure full functionality and quality.

---

# 📝 Changes Made:

What does this PR address?

- [ ] 🐞 **Bugfix**
- [ ] ✨ **Feature**
- [x ] 🎨 **Code Style Update** (formatting, renaming)
- [ ] 🔄 **Refactor** (no functional or API changes)
- [ ] 📦 **Build-Related Changes**
- [ ] 📚 **Documentation** updates or additions
- [ ] ✅ **Testing**
- [ ] 🧩 **Other** (please specify): _[Provide details here]_

---

# 🔍 Summary of Work Done:

- Key tasks accomplished in bullet points
-action's status (Accepted, Rejected, or any other status like Pending) and returns an emoji:

✅ if the application is Accepted.
❌ if the application is Rejected.
⏳ for any other status, typically representing Pending

I use a div element as the main container, styled with Tailwind CSS classes: I added padding (p-4) for internal spacing.
I set up a responsive grid layout (grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3), which adjusts the number of columns based on screen size: 1 column on small screens.
2 columns on medium screens.
3 columns on large screens.
I added a gap (gap-6) between grid items for better spacing.

for each application, I render a div element with a unique key (key={index}) and specific styling: I used classes like border, rounded-lg, p-4, and shadow-lg to create a card with rounded corners, padding, and a shadow effect. I implemented a hover effect (transform transition duration-300 hover:scale-105) that scales the card smoothly when the user hovers over it. I applied conditional styling based on the application status: Green (bg-green-50 border-green-200) for Accepted applications. Red (bg-red-50 border-red-200) for Rejected applications. Yellow (bg-yellow-50 border-yellow-200) for other statuses like Pending.

Inside each card:
I display the info in the cards + the emojis

---

# 📸 Screenshots:

If applicable, please provide screenshots to help illustrate the changes
![image](https://github.com/user-attachments/assets/f32535f6-a56d-4325-ac2b-ef645bed3bfb)



---
